### PR TITLE
add viewbox compiling and passing down to child

### DIFF
--- a/src/Chart.js
+++ b/src/Chart.js
@@ -18,13 +18,19 @@ const React = require('react'),
  * @example ../docs/examples/Chart.md
  */
 function Chart(props) {
+    let viewBoxTotal, viewBoxWidth, viewBoxHeight;
+    if (props.viewBox) {
+        viewBoxTotal = props.viewBox.split(' ').map(Number);
+        viewBoxWidth = viewBoxTotal[2];
+        viewBoxHeight = viewBoxTotal[3];
+    }
 
     const children = helpers.proxyChildren(
         props.children,
         props,
         {
-            layerWidth: props.width,
-            layerHeight: props.height,
+            layerWidth: props.width ? props.width : viewBoxWidth,
+            layerHeight: props.height ? props.height : viewBoxHeight,
             scaleX: _.defaults({}, props.scaleX, {
                 direction: 1,
                 paddingStart: 0.5,


### PR DESCRIPTION
Okay so you can update the docs after this.

After your latest merges, viewbox is generated automatically from width and height properties. Thing is that we don't need to have `width` and `height` properties if we want svg to be responsive.

So there are 2 main ways to create a `<Chart />`:

1. `<Chart width={200} height={250} />` <- `viewBox` of `0 0 200 250` will be added, though the svg won't be responsive. `layerWidth` and `layerHeight` of child elements are going to be `200` and `250`

2. `<Chart viewBox={'0 0 200 250'} /> <- `width` and `height` won't be added there, but `layerWidth` and `layerHeight` is going to be passed down to child, so svg is responsive now.

Please, send me a email here gbarkhatov@gmail.com

I am trying to decrease the size by removing unused lodash dependencies. Problem is that it's rumble charts are working when I import from npm, but I cannot import them from `src` or `build` from forked repo.