### PR TITLE
Optimized lodash imports

### DIFF
--- a/src/Animate.js
+++ b/src/Animate.js
@@ -1,6 +1,12 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
+import {
+    isFunction,
+    isString,
+    isUndefined,
+    omitBy,
+    pick,
+} from 'lodash';
 import d3 from 'd3';
 import {timer} from 'd3-timer';
 
@@ -26,15 +32,15 @@ export default class Animate extends Component {
 
     componentWillReceiveProps(nextProps) {
         const interpolate = d3.interpolateObject(
-            _.pick(this.state, this.props.interpolateProps),
-            _.pick(nextProps, this.props.interpolateProps)
+            pick(this.state, this.props.interpolateProps),
+            pick(nextProps, this.props.interpolateProps)
         );
 
         const {duration, onStart, onEnd, logFPS} = this.props;
         let {ease} = this.props;
-        ease = _.isString(ease) ?
+        ease = isString(ease) ?
             d3.ease(ease) :
-            (_.isFunction(ease) ? ease : d3.ease('linear'));
+            (isFunction(ease) ? ease : d3.ease('linear'));
 
         let i = 0;
         this._timer && this._timer.stop();
@@ -65,7 +71,7 @@ export default class Animate extends Component {
         return <g className={props.className}>
             {proxyChildren(
                 props.children,
-                _.omitBy(state, _.isUndefined),
+                omitBy(state, isUndefined),
                 {
                     layerWidth: state.layerWidth,
                     layerHeight: state.layerHeight,
@@ -117,7 +123,7 @@ Animate.defaultProps = {
 
 d3.interpolators.push(function(a, b) {
     let c, i, an = typeof a == 'number';
-    if (b && !_.isUndefined(b.x) && !_.isUndefined(b.y)) {
+    if (b && !isUndefined(b.x) && !isUndefined(b.y)) {
         // point
         a = a || {};
         c = {};
@@ -142,7 +148,7 @@ d3.interpolators.push(function(a, b) {
             }
             return c;
         };
-    } else if (b && b[0] && (!_.isUndefined(b[0].data) || (!_.isUndefined(b[0].x) && !_.isUndefined(b[0].y)))) {
+    } else if (b && b[0] && (!isUndefined(b[0].data) || (!isUndefined(b[0].x) && !isUndefined(b[0].y)))) {
         // series or points
         a = a || [];
         c = [];

--- a/src/Bars.js
+++ b/src/Bars.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
+import { map } from 'lodash';
 
 import value from './helpers/value';
 import normalizeNumber from './helpers/normalizeNumber';
@@ -86,7 +86,7 @@ export default class Bars extends Component {
             style={seriesStyle}
             {...seriesAttributes}>
 
-            {series && _.map(series.data, (point, pointIndex) => {
+            {series && map(series.data, (point, pointIndex) => {
                 let y0 = point.y0 ? y(point.y0) : this._y0;
                 let y1 = y(point.y);
                 let x1 = x(point.x) + deltaX * (scaleX.direction || 1);
@@ -164,7 +164,7 @@ export default class Bars extends Component {
             className={className}
             style={style}
             opacity={opacity}>
-            {_.map(props.series, this.renderSeries)}
+            {map(props.series, this.renderSeries)}
         </g>;
 
     }

--- a/src/Chart.js
+++ b/src/Chart.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import d3 from 'd3';
-import _ from 'lodash';
+import { defaults, map, omit } from 'lodash';
 
 import proxyChildren from './helpers/proxyChildren';
 import normalizeNumber from './helpers/normalizeNumber';
@@ -25,7 +25,7 @@ export default function Chart(props) {
     height = height || layerHeight;
 
     if (viewBox) {
-        let viewBoxTotal = _.map(viewBox.split(' '), value => parseInt(value));
+        let viewBoxTotal = map(viewBox.split(' '), value => parseInt(value));
         width = width || viewBoxTotal[2];
         height = height || viewBoxTotal[3];
     }
@@ -36,7 +36,7 @@ export default function Chart(props) {
         {
             layerWidth: width,
             layerHeight: height,
-            scaleX: _.defaults({}, props.scaleX, {
+            scaleX: defaults({}, props.scaleX, {
                 direction: 1,
                 paddingStart: 0.5,
                 paddingEnd: 0.5,
@@ -59,7 +59,7 @@ export default function Chart(props) {
                         .domain(direction >= 0 ? [minX, maxX] : [maxX, minX]);
                 }
             }),
-            scaleY: _.defaults({}, props.scaleY, {
+            scaleY: defaults({}, props.scaleY, {
                 direction: 1,
                 paddingStart: 0,
                 paddingEnd: 0,
@@ -88,7 +88,7 @@ export default function Chart(props) {
     const Tag = props.tag;
 
     return <Tag
-        {..._.omit(props, [
+        {...omit(props, [
             'series', 'tag', 'children', 'minX', 'maxX', 'minY', 'maxY',
             'scaleX', 'scaleY', 'layerWidth', 'layerHeight'
         ])}

--- a/src/Cloud.js
+++ b/src/Cloud.js
@@ -1,6 +1,13 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
+import {
+    defaults,
+    forEach,
+    groupBy,
+    map,
+    reduce,
+    sortBy,
+} from 'lodash';
 import d3 from 'd3';
 import cloud from 'd3-cloud';
 
@@ -37,9 +44,9 @@ export default class Cloud extends Component {
             .range([props.minFontSize, props.maxFontSize])
             .domain([props.minY, props.maxY]);
 
-        const words = _.reduce(series, (words, {data}, seriesIndex) => {
-            _.forEach(data, (point, pointIndex) => {
-                words.push(_.defaults({
+        const words = reduce(series, (words, {data}, seriesIndex) => {
+            forEach(data, (point, pointIndex) => {
+                words.push(defaults({
                     text: point.label,
                     size: point.y,
                     seriesIndex,
@@ -62,9 +69,9 @@ export default class Cloud extends Component {
             .timeInterval(15)
             .fontSize(d => scale(d.size))
             .on('end', function(series, labels) {
-                labels = _.map(
-                    _.groupBy(labels, 'seriesIndex'),
-                    labels => _.sortBy(labels, 'pointIndex')
+                labels = map(
+                    groupBy(labels, 'seriesIndex'),
+                    labels => sortBy(labels, 'pointIndex')
                 );
                 this.setState({series, labels});
             }.bind(this, series))
@@ -101,7 +108,7 @@ export default class Cloud extends Component {
         return <g
             className={className} style={style} opacity={opacity}
             transform={'translate(' + (layerWidth / 2) + ',' + (layerHeight / 2) + ')'}>
-            {_.map(state.series, (series, seriesIndex) => {
+            {map(state.series, (series, seriesIndex) => {
 
                 let {seriesVisible, seriesStyle, seriesAttributes} = props;
 
@@ -119,7 +126,7 @@ export default class Cloud extends Component {
                     style={seriesStyle}
                     opacity={series.opacity}
                     {...seriesAttributes}>
-                    {_.map(series.data, (point, pointIndex) => {
+                    {map(series.data, (point, pointIndex) => {
 
                         let {labelVisible, labelAttributes, labelStyle} = props;
                         let label = labels[seriesIndex] && labels[seriesIndex][pointIndex];

--- a/src/Dots.js
+++ b/src/Dots.js
@@ -1,6 +1,12 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
+import {
+    isArray,
+    isFunction,
+    isString,
+    keys,
+    map,
+} from 'lodash';
 import d3 from 'd3';
 
 import value from './helpers/value';
@@ -166,18 +172,18 @@ export default class Dots extends Component {
         const color = this.color;
         let dot;
 
-        if (_.isFunction(dotRender)) {
+        if (isFunction(dotRender)) {
             dot = dotRender({seriesIndex, pointIndex, point, dotStyle, dotAttributes, props, color});
         } else {
-            if (_.isString(dotType)) {
+            if (isString(dotType)) {
                 dot = this[methods[dotType]] &&
                     this[methods[dotType]]({
                         seriesIndex, pointIndex, point,
                         dotStyle, dotAttributes, props, color
                     });
 
-            } else if (_.isArray(dotType)) {
-                dot = _.map(dotType, (dotType, key) => {
+            } else if (isArray(dotType)) {
+                dot = map(dotType, (dotType, key) => {
                     return this[methods[dotType]]({
                         key, seriesIndex, pointIndex, point, dotStyle, dotAttributes, props, color
                     });
@@ -207,7 +213,7 @@ export default class Dots extends Component {
         this.color = colorFunc(colors);
 
         return <g className={className} style={style} opacity={opacity}>
-            {_.map(props.series, (series, index) => {
+            {map(props.series, (series, index) => {
 
                 let {seriesVisible, seriesStyle, seriesAttributes} = props;
 
@@ -226,7 +232,7 @@ export default class Dots extends Component {
                     opacity={series.opacity}
                     {...seriesAttributes}>
 
-                    {_.map(series.data, (point, pointIndex) => {
+                    {map(series.data, (point, pointIndex) => {
                         let y1 = y(point.y);
                         let x1 = x(point.x);
 
@@ -260,7 +266,7 @@ Dots.propTypes = {
      * Possible values: `"dot"`, `"circle"`, `"ellipse"`, `"symbol"`, `"label"`, `"path"`.
      */
     dotType: PropTypes.oneOfType([
-        PropTypes.oneOf(_.keys(methods)),
+        PropTypes.oneOf(keys(methods)),
         PropTypes.array,
         PropTypes.func
     ]),

--- a/src/Gradient.js
+++ b/src/Gradient.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
+import { isUndefined } from 'lodash';
 
 let counter = 0;
 
@@ -47,11 +47,11 @@ export default class Gradient extends Component {
             cx, cy, fx, fy, r
         } = this.props;
 
-        const _cx = _.isUndefined(cx) ? (center && center[0]) : cx;
-        const _cy = _.isUndefined(cy) ? (center && center[1]) : cy;
-        const _fx = _.isUndefined(fx) ? (focalPoint && focalPoint[0]) : fx;
-        const _fy = _.isUndefined(fy) ? (focalPoint && focalPoint[1]) : fy;
-        const _r = _.isUndefined(r) ? radius : r;
+        const _cx = isUndefined(cx) ? (center && center[0]) : cx;
+        const _cy = isUndefined(cy) ? (center && center[1]) : cy;
+        const _fx = isUndefined(fx) ? (focalPoint && focalPoint[0]) : fx;
+        const _fy = isUndefined(fy) ? (focalPoint && focalPoint[1]) : fy;
+        const _r = isUndefined(r) ? radius : r;
 
         return <radialGradient
             id={this.getId()}
@@ -64,10 +64,10 @@ export default class Gradient extends Component {
     renderLinear() {
         const {from, to, gradientUnits, spreadMethod, gradientTransform, x1, y1, x2, y2} = this.props;
 
-        const _x1 = _.isUndefined(x1) ? (from && from[0]) : x1;
-        const _y1 = _.isUndefined(y1) ? (from && from[1]) : y1;
-        const _x2 = _.isUndefined(x2) ? (to && to[0]) : x2;
-        const _y2 = _.isUndefined(y2) ? (to && to[1]) : y2;
+        const _x1 = isUndefined(x1) ? (from && from[0]) : x1;
+        const _y1 = isUndefined(y1) ? (from && from[1]) : y1;
+        const _x2 = isUndefined(x2) ? (to && to[0]) : x2;
+        const _y2 = isUndefined(y2) ? (to && to[1]) : y2;
 
         return <linearGradient
             id={this.getId()}

--- a/src/Handlers.js
+++ b/src/Handlers.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
+import { forEach, sortBy } from 'lodash';
 
 import proxyChildren from './helpers/proxyChildren';
 
@@ -70,8 +70,8 @@ export default class Handlers extends Component {
 
         let closestPoints = [];
         let minDistance = sensitivity;
-        _.forEach(series, (series, seriesIndex) => {
-            _.forEach(series.data, (point, pointIndex) => {
+        forEach(series, (series, seriesIndex) => {
+            forEach(series.data, (point, pointIndex) => {
                 let distance;
                 switch (props.distance) {
                 case 'x':
@@ -99,7 +99,7 @@ export default class Handlers extends Component {
                 }
             });
         });
-        closestPoints = _.sortBy(closestPoints, 'distance');
+        closestPoints = sortBy(closestPoints, 'distance');
 
         handler({
             clientX: realX,

--- a/src/Lines.js
+++ b/src/Lines.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
+import { map, isNumber } from 'lodash';
 import d3 from 'd3';
 
 import value from './helpers/value';
@@ -24,7 +24,7 @@ export default function Lines(props) {
     const color = colorFunc(colors);
 
     return <g className={className} style={style} opacity={opacity}>
-        {_.map(series, (series, index) => {
+        {map(series, (series, index) => {
 
             let {seriesVisible, seriesStyle, seriesAttributes} = props;
             let {lineVisible, lineStyle, lineAttributes, lineWidth} = props;
@@ -63,7 +63,7 @@ export default function Lines(props) {
 
                 let lineColor = series.color || color(index);
 
-                line.defined(point => _.isNumber(point.y))
+                line.defined(point => isNumber(point.y))
                     .interpolate(props.interpolation);
 
                 lineAttributes = value(lineAttributes, {seriesIndex: index, series, props});

--- a/src/Pies.js
+++ b/src/Pies.js
@@ -1,6 +1,14 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
+import {
+    assign,
+    forEach,
+    isArray,
+    isEmpty,
+    map,
+    range,
+    uniq,
+} from 'lodash';
 import d3 from 'd3';
 
 import normalizeNumber from './helpers/normalizeNumber';
@@ -58,7 +66,7 @@ export default class Pies extends Component {
             if (props.combined) {
                 return baseWidth - innerPadding;
             } else {
-                let seriesCount = _.isEmpty(props.series) ? 1 : props.series.length;
+                let seriesCount = isEmpty(props.series) ? 1 : props.series.length;
                 return (baseWidth - groupPadding) / seriesCount - innerPadding;
             }
         }
@@ -118,7 +126,7 @@ export default class Pies extends Component {
             .outerRadius(radius + halfWidth);
 
         let fillColor = point.color || series.color || this.color(seriesIndex);
-        if (_.isArray(fillColor) && _.uniq(fillColor).length === 1) {
+        if (isArray(fillColor) && uniq(fillColor).length === 1) {
             fillColor = fillColor[0];
         }
 
@@ -131,7 +139,7 @@ export default class Pies extends Component {
         });
         pieAttributes = value(pieAttributes, {seriesIndex, pointIndex, point, series, props});
 
-        const pathProps = _.assign({
+        const pathProps = assign({
             style: pieStyle,
             fill: fillColor,
             fillOpacity: point.opacity
@@ -139,10 +147,10 @@ export default class Pies extends Component {
 
         let pathList = [];
         // fill color interpolation
-        if (_.isArray(fillColor)) {
+        if (isArray(fillColor)) {
 
             let interpolateAngle = d3.interpolate(startAngle, endAngle);
-            _.forEach(fillColor, (color, index) => {
+            forEach(fillColor, (color, index) => {
 
                 if (index === fillColor.length - 1) {
                     return;
@@ -151,7 +159,7 @@ export default class Pies extends Component {
                 let interpolateFillColor = d3.interpolate(color, fillColor[index + 1]);
                 let step = 1 / ((endAngle - startAngle) / this.props.gradientStep);
 
-                _.forEach(_.range(0, 1, step), (i) => {
+                forEach(range(0, 1, step), (i) => {
 
                     pathProps.fill = interpolateFillColor(i);
                     let angleIndex = (index + i) / (fillColor.length - 1);
@@ -221,7 +229,7 @@ export default class Pies extends Component {
             style={style}
             transform={'translate(' + (coords.x + outerRadius) + ' ' + (coords.y + outerRadius) + ')'}
             opacity={opacity}>
-            {_.map(series, (series, index) => {
+            {map(series, (series, index) => {
 
                 let {seriesVisible, seriesAttributes, seriesStyle} = props;
 
@@ -246,7 +254,7 @@ export default class Pies extends Component {
                     opacity={series.opacity}
                     {...seriesAttributes}>
 
-                    {_.map(series.data, (point, pointIndex) => {
+                    {map(series.data, (point, pointIndex) => {
                         let startAngle = (point.y0 ? circularScale(point.y0) : _startAngle) + halfPadAngle;
                         let endAngle = circularScale(point.y) - halfPadAngle;
                         let radius = radialScale(point.x) - deltaRadial * (props.scaleX.direction || 1);

--- a/src/RadialLines.js
+++ b/src/RadialLines.js
@@ -1,6 +1,6 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
+import { isNumber, map } from 'lodash';
 import d3 from 'd3';
 
 import normalizeNumber from './helpers/normalizeNumber';
@@ -63,7 +63,7 @@ export default class RadialLines extends Component {
             transform={'translate(' + (coords.x + outerRadius) + ' ' + (coords.y + outerRadius) + ')'}
             opacity={opacity}>
 
-            {_.map(series, (series, index) => {
+            {map(series, (series, index) => {
 
                 let {seriesVisible, seriesAttributes, seriesStyle} = props;
                 let {lineVisible, lineStyle, lineAttributes, lineWidth} = props;
@@ -89,7 +89,7 @@ export default class RadialLines extends Component {
                     const lineColor = series.color || color(index);
 
                     line.angle(point => circularScale(point.x))
-                        .defined(point => _.isNumber(point.y))
+                        .defined(point => isNumber(point.y))
                         .interpolate(this.props.interpolation);
 
                     lineAttributes = value(lineAttributes, {seriesIndex: index, series, props});

--- a/src/Ticks.js
+++ b/src/Ticks.js
@@ -1,6 +1,13 @@
 import React, {Component} from 'react';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
+import {
+    isNumber,
+    isPlainObject,
+    isString,
+    isUndefined,
+    map,
+    range,
+} from 'lodash';
 
 import normalizeNumber from './helpers/normalizeNumber';
 import value from './helpers/value';
@@ -33,20 +40,20 @@ export default class Ticks extends Component {
         const min = axis === 'y' ? minY : minX;
         const length = max - min;
 
-        if (_.isUndefined(minDistance)) {
+        if (isUndefined(minDistance)) {
             minDistance = Math.min(1, length);
         }
 
-        if (_.isUndefined(maxTicks)) {
+        if (isUndefined(maxTicks)) {
             maxTicks = Math.min((length + minDistance) / minDistance, 5);
         }
 
-        if (_.isUndefined(distance)) {
+        if (isUndefined(distance)) {
             distance = Math.max(minDistance, length / maxTicks);
             distance = Math.ceil(distance / minDistance) * minDistance;
         }
 
-        return _.range(min, max + minDistance, distance);
+        return range(min, max + minDistance, distance);
     }
 
     // render
@@ -56,7 +63,7 @@ export default class Ticks extends Component {
         const {axis, className, layerWidth, layerHeight, scaleX, scaleY} = props;
         let {tickStyle, tickAttributes, tickVisible} = props;
 
-        if (_.isNumber(tick)) {
+        if (isNumber(tick)) {
             tick = {[axis]: tick};
         }
 
@@ -100,7 +107,7 @@ export default class Ticks extends Component {
             label = value([tick.label, label, tick[axis]], {index, ticksLength, tick, props});
             labelFormat = value(labelFormat, label) || label;
 
-            if (_.isString(label) || _.isNumber(label)) {
+            if (isString(label) || isNumber(label)) {
                 label = <text
                     style={labelStyle}
                     className={className && (className + '-label ' + className + '-label-' + index)}
@@ -161,16 +168,16 @@ export default class Ticks extends Component {
                 'left');
 
         ticks = value([ticks], props);
-        if (_.isNumber(ticks)) {
+        if (isNumber(ticks)) {
             ticks = {maxTicks: ticks};
         }
         ticks = ticks || {};
-        if (_.isPlainObject(ticks)) {
+        if (isPlainObject(ticks)) {
             ticks = this.generateTicks(ticks);
         }
 
         return <g className={className} style={style} opacity={props.opacity}>
-            {_.map(ticks, this.renderTick.bind(this, ticks.length))}
+            {map(ticks, this.renderTick.bind(this, ticks.length))}
         </g>;
     }
 

--- a/src/Title.js
+++ b/src/Title.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
+import { isFunction, isString } from 'lodash';
 
 import getCoords from './helpers/getCoords';
 
@@ -22,9 +22,9 @@ export default function Title(props) {
         className={className}
         transform={'translate(' + x + ' ' + y + ')'}
         style={style}>
-        {_.isString(children) ?
+        {isString(children) ?
             <text>{children}</text> :
-            (_.isFunction(children) ? children(props) : children)}
+            (isFunction(children) ? children(props) : children)}
     </g>;
 }
 

--- a/src/Transform.js
+++ b/src/Transform.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import _ from 'lodash';
+import { isUndefined } from 'lodash';
 
 import transform from './helpers/transform';
 import proxyChildren from './helpers/proxyChildren';
@@ -21,10 +21,10 @@ export default function Transform(props) {
         props.children,
         newProps,
         {
-            layerWidth: _.isUndefined(newProps.layerWidth) ? layerWidth : newProps.layerWidth,
-            layerHeight: _.isUndefined(newProps.layerHeight) ? layerHeight : newProps.layerHeight,
-            scaleX: _.isUndefined(newProps.scaleX) ? scaleX : newProps.scaleX,
-            scaleY: _.isUndefined(newProps.scaleY) ? scaleY : newProps.scaleY
+            layerWidth: isUndefined(newProps.layerWidth) ? layerWidth : newProps.layerWidth,
+            layerHeight: isUndefined(newProps.layerHeight) ? layerHeight : newProps.layerHeight,
+            scaleX: isUndefined(newProps.scaleX) ? scaleX : newProps.scaleX,
+            scaleY: isUndefined(newProps.scaleY) ? scaleY : newProps.scaleY
         }
     );
 

--- a/src/helpers/colorFunc.js
+++ b/src/helpers/colorFunc.js
@@ -1,12 +1,12 @@
-import _ from 'lodash';
+import { isEmpty, isFunction, isString } from 'lodash';
 import d3 from 'd3';
 
 export default function colorFunc(colors) {
-    if (_.isFunction(colors)) {
+    if (isFunction(colors)) {
         return colors;
-    } else if (_.isEmpty(colors)) {
+    } else if (isEmpty(colors)) {
         return d3.scale.category20();
-    } else if (_.isString(colors)) {
+    } else if (isString(colors)) {
         return d3.scale[colors]();
     } else {
         return d3.scale.ordinal().range(colors);

--- a/src/helpers/getCoords.js
+++ b/src/helpers/getCoords.js
@@ -1,14 +1,19 @@
-import _ from 'lodash';
+import {
+    isArray,
+    isString,
+    isUndefined,
+    map,
+} from 'lodash';
 
 import normalizeNumber from './normalizeNumber';
 
 export default function getCoords(position, layerWidth, layerHeight, width = 0, height = 0) {
 
-    if (_.isString(position)) {
-        position = _.map(position.trim().split(' '), value => value.trim());
+    if (isString(position)) {
+        position = map(position.trim().split(' '), value => value.trim());
     }
-    if (_.isArray(position)) {
-        position = _.map(position, pos => _.isString(pos) ? pos.trim().toLowerCase() : pos);
+    if (isArray(position)) {
+        position = map(position, pos => isString(pos) ? pos.trim().toLowerCase() : pos);
         let [x, y] = position;
         if (['top', 'bottom', 'middle'].indexOf(position[0]) !== -1) {
             y = position[0];
@@ -16,7 +21,7 @@ export default function getCoords(position, layerWidth, layerHeight, width = 0, 
         if (['left', 'right', 'center'].indexOf(position[1]) !== -1) {
             x = position[1];
         }
-        if (_.isString(x)) {
+        if (isString(x)) {
             if (x === 'left') {
                 x = 0;
             } else if (x === 'right') {
@@ -26,10 +31,10 @@ export default function getCoords(position, layerWidth, layerHeight, width = 0, 
             } else {
                 x = normalizeNumber(x, layerWidth);
             }
-        } else if (_.isUndefined(x)) {
+        } else if (isUndefined(x)) {
             x = 0;
         }
-        if (_.isString(y)) {
+        if (isString(y)) {
             if (y === 'top') {
                 y = 0;
             } else if (y === 'bottom') {
@@ -39,7 +44,7 @@ export default function getCoords(position, layerWidth, layerHeight, width = 0, 
             } else {
                 y = normalizeNumber(y, layerHeight);
             }
-        } else if (_.isUndefined(y)) {
+        } else if (isUndefined(y)) {
             y = 0;
         }
         return {x, y};

--- a/src/helpers/normalizeNumber.js
+++ b/src/helpers/normalizeNumber.js
@@ -1,7 +1,7 @@
-import _ from 'lodash';
+import { isString } from 'lodash';
 
 export default function normalizeNumber(number, absolute = null) {
-    if (_.isString(number)) {
+    if (isString(number)) {
         if (number.substr(-1, 1) === '%') {
             number = ((parseFloat(number) || 0) / 100) * absolute;
         } else if (number === 'left' || number === 'top') {

--- a/src/helpers/normalizeSeries.js
+++ b/src/helpers/normalizeSeries.js
@@ -1,7 +1,15 @@
-import _ from 'lodash';
+import {
+    defaults,
+    isArray,
+    isEmpty,
+    isNumber,
+    isUndefined,
+    map,
+    omitBy,
+} from 'lodash';
 
 const isInvalidLimit = value => {
-    return _.isUndefined(value) || value === Infinity || value === -Infinity;
+    return isUndefined(value) || value === Infinity || value === -Infinity;
 };
 
 export default function normalizeSeries(props) {
@@ -10,63 +18,63 @@ export default function normalizeSeries(props) {
         minX = Infinity,
         minY = Infinity;
 
-    let series = _.map(props.series, series => {
+    let series = map(props.series, series => {
 
-        let data = _.map(series.data, (item, index) => {
+        let data = map(series.data, (item, index) => {
 
             let d;
             if (!props.seriesNormalized) {
                 d = {};
-                if (_.isNumber(item)) {
+                if (isNumber(item)) {
                     d.x = index;
                     d.y = item;
-                } else if (_.isArray(item)) {
+                } else if (isArray(item)) {
                     d.x = item[0];
                     d.y = item[1];
                 } else {
                     d = item || {};
-                    if (_.isUndefined(d.x)) {
+                    if (isUndefined(d.x)) {
                         d.x = index;
                     }
                 }
             } else {
                 d = item;
             }
-            if (_.isUndefined(props.maxX)) {
+            if (isUndefined(props.maxX)) {
                 maxX = Math.max(maxX, d.x || 0);
             }
-            if (_.isUndefined(props.maxY)) {
+            if (isUndefined(props.maxY)) {
                 maxY = Math.max(maxY, d.y || 0);
             }
-            if (_.isUndefined(props.minX)) {
+            if (isUndefined(props.minX)) {
                 minX = Math.min(minX, d.x || 0);
             }
-            if (_.isUndefined(props.minY)) {
+            if (isUndefined(props.minY)) {
                 minY = Math.min(minY, d.y || 0);
             }
 
             return d;
         });
 
-        return _.defaults({data}, series);
+        return defaults({data}, series);
     });
-    if (_.isEmpty(series)) {
+    if (isEmpty(series)) {
         series = undefined;
     }
-    if (!_.isUndefined(props.maxX)) {
+    if (!isUndefined(props.maxX)) {
         maxX = props.maxX;
     }
-    if (!_.isUndefined(props.maxY)) {
+    if (!isUndefined(props.maxY)) {
         maxY = props.maxY;
     }
-    if (!_.isUndefined(props.minX)) {
+    if (!isUndefined(props.minX)) {
         minX = props.minX;
     }
-    if (!_.isUndefined(props.minY)) {
+    if (!isUndefined(props.minY)) {
         minY = props.minY;
     }
 
-    return _.omitBy({
+    return omitBy({
         seriesNormalized: true,
         series,
         maxX,

--- a/src/helpers/proxyChildren.js
+++ b/src/helpers/proxyChildren.js
@@ -1,5 +1,17 @@
 import React from 'react';
-import _ from 'lodash';
+import {
+    assign,
+    defaults,
+    defaultsDeep,
+    filter,
+    isArray,
+    isFunction,
+    isNumber,
+    isUndefined,
+    map,
+    omitBy,
+    pick,
+} from 'lodash';
 
 import normalizeSeries from './normalizeSeries';
 
@@ -7,9 +19,9 @@ const limitsPropNames = ['maxX', 'maxY', 'minX', 'minY'];
 
 export default function proxyChildren(children, seriesProps = {}, extraProps = {}) {
 
-    const limits = _.pick(seriesProps, limitsPropNames);
+    const limits = pick(seriesProps, limitsPropNames);
     seriesProps = normalizeSeries(seriesProps);
-    const limitsCalculated = _.pick(seriesProps, limitsPropNames);
+    const limitsCalculated = pick(seriesProps, limitsPropNames);
     const {series} = seriesProps;
 
     return React.Children.map(children, child => {
@@ -19,27 +31,27 @@ export default function proxyChildren(children, seriesProps = {}, extraProps = {
         }
 
         let props = {};
-        _.assign(props, child.props);
-        _.defaultsDeep(props, _.isFunction(extraProps) ? extraProps(child) : extraProps);
+        assign(props, child.props);
+        defaultsDeep(props, isFunction(extraProps) ? extraProps(child) : extraProps);
 
-        const childLimits = _.pick(child.props, limitsPropNames);
-        const childSeriesProps = normalizeSeries(_.defaults(child.props, {
+        const childLimits = pick(child.props, limitsPropNames);
+        const childSeriesProps = normalizeSeries(defaults(child.props, {
             layerWidth: props.layerWidth,
             layerHeight: props.layerHeight
         }));
-        const childLimitsCalculated = _.pick(childSeriesProps, limitsPropNames);
+        const childLimitsCalculated = pick(childSeriesProps, limitsPropNames);
 
-        _.defaults(props, childLimits, limits, childLimitsCalculated, limitsCalculated);
+        defaults(props, childLimits, limits, childLimitsCalculated, limitsCalculated);
 
         if (!child.props.series) {
-            if (_.isUndefined(child.props.seriesIndex)) {
+            if (isUndefined(child.props.seriesIndex)) {
                 props.series = series;
-            } else if (_.isNumber(child.props.seriesIndex)) {
+            } else if (isNumber(child.props.seriesIndex)) {
                 props.series = [series[child.props.seriesIndex]];
-            } else if (_.isArray(child.props.seriesIndex)) {
-                props.series = _.map(child.props.seriesIndex, index => series[index]);
-            } else if (_.isFunction(child.props.seriesIndex)) {
-                props.series = _.filter(series, child.props.seriesIndex);
+            } else if (isArray(child.props.seriesIndex)) {
+                props.series = map(child.props.seriesIndex, index => series[index]);
+            } else if (isFunction(child.props.seriesIndex)) {
+                props.series = filter(series, child.props.seriesIndex);
             } else {
                 props.series = series;
             }
@@ -48,7 +60,7 @@ export default function proxyChildren(children, seriesProps = {}, extraProps = {
         }
         props.seriesNormalized = true;
 
-        props = _.omitBy(props, _.isUndefined);
+        props = omitBy(props, isUndefined);
 
         return React.cloneElement(child, props);
 

--- a/src/helpers/transform.js
+++ b/src/helpers/transform.js
@@ -1,22 +1,29 @@
-import _ from 'lodash';
+import {
+    defaults,
+    isArray,
+    isFunction,
+    isObject,
+    isString,
+    reduce,
+} from 'lodash';
 
 import transforms from './transforms';
 
 export default function transform(props, method, options = null) {
-    if (!_.isArray(method)) {
+    if (!isArray(method)) {
         method = [method];
     }
 
-    return _.reduce(method, (props, method) => {
-        if (_.isString(method)) {
-            if (_.isFunction(transforms[method])) {
-                return _.defaults(transforms[method](props, options), props);
+    return reduce(method, (props, method) => {
+        if (isString(method)) {
+            if (isFunction(transforms[method])) {
+                return defaults(transforms[method](props, options), props);
             } else {
                 return props;
             }
-        } else if (_.isFunction(method)) {
-            return _.defaults(method(props, options), props);
-        } else if (_.isObject(method)) {
+        } else if (isFunction(method)) {
+            return defaults(method(props, options), props);
+        } else if (isObject(method)) {
             return transform(props, method.method, method.options);
         } else {
             return props;

--- a/src/helpers/transforms/reverse.js
+++ b/src/helpers/transforms/reverse.js
@@ -1,7 +1,7 @@
-import _ from 'lodash';
+import { cloneDeep, isArray } from 'lodash';
 
 export default function reverse({series, seriesNormalized, minX, maxX, maxY, minY}) {
-    series = _.isArray(series) ? _.cloneDeep(series).reverse() : series;
+    series = isArray(series) ? cloneDeep(series).reverse() : series;
     return {
         series,
         seriesNormalized,

--- a/src/helpers/transforms/rotate.js
+++ b/src/helpers/transforms/rotate.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { cloneDeep } from 'lodash';
 
 export default function rotate(props) {
     const {series, seriesNormalized, minX, maxX, maxY, minY} = props;
@@ -6,8 +6,8 @@ export default function rotate(props) {
 
     const {paddingLeft, paddingRight} = scaleX;
     const {paddingTop, paddingBottom} = scaleY;
-    scaleX = _.cloneDeep(scaleX);
-    scaleY = _.cloneDeep(scaleY);
+    scaleX = cloneDeep(scaleX);
+    scaleY = cloneDeep(scaleY);
     scaleX.paddingLeft = paddingTop;
     scaleX.paddingRight = paddingBottom;
     scaleX.swap = !scaleX.swap;

--- a/src/helpers/transforms/sort.js
+++ b/src/helpers/transforms/sort.js
@@ -1,32 +1,37 @@
-import _ from 'lodash';
+import {
+    defaults,
+    isString,
+    map,
+    sortBy,
+} from 'lodash';
 
 export default function sort(props, options) {
     let {direction} = options || {};
-    direction = _.isString(direction) ? direction.trim().toLowerCase() : 'asc';
+    direction = isString(direction) ? direction.trim().toLowerCase() : 'asc';
 
     let {series, seriesNormalized, maxX, maxY, minX, minY} = props;
 
-    series = _.map(series, series => {
+    series = map(series, series => {
 
         const newSeries = {};
 
-        newSeries.data = _.sortBy(series.data, 'y');
+        newSeries.data = sortBy(series.data, 'y');
 
         if (direction === 'desc') {
             newSeries.data.reverse();
         }
 
-        newSeries.data = _.map(newSeries.data, (point, pointIndex) => {
+        newSeries.data = map(newSeries.data, (point, pointIndex) => {
             const newPoint = {
                 realX: point.x,
                 x: pointIndex
             };
-            return _.defaults(newPoint, point);
+            return defaults(newPoint, point);
         });
 
-        newSeries.data = _.sortBy(newSeries.data, 'realX');
+        newSeries.data = sortBy(newSeries.data, 'realX');
 
-        return _.defaults(newSeries, series);
+        return defaults(newSeries, series);
 
     });
 

--- a/src/helpers/transforms/stack.js
+++ b/src/helpers/transforms/stack.js
@@ -1,4 +1,10 @@
-import _ from 'lodash';
+import {
+    defaults,
+    isUndefined,
+    map,
+    max,
+    min,
+} from 'lodash';
 
 export default function stack(props, options) {
     const {normalize} = options || {};
@@ -6,12 +12,12 @@ export default function stack(props, options) {
     let {series, seriesNormalized, maxX, maxY, minX, minY} = props;
 
     const stackedY = [], lowestY = [];
-    series = _.map(series, series => {
+    series = map(series, series => {
 
         const newSeries = {
-            data: _.map(series.data, (point, pointIndex) => {
+            data: map(series.data, (point, pointIndex) => {
                 stackedY[pointIndex] = stackedY[pointIndex] || 0;
-                if (_.isUndefined(lowestY[pointIndex])) {
+                if (isUndefined(lowestY[pointIndex])) {
                     lowestY[pointIndex] = stackedY[pointIndex];
                 }
                 const newPoint = {
@@ -20,31 +26,31 @@ export default function stack(props, options) {
                 };
                 stackedY[pointIndex] = newPoint.y;
 
-                return _.defaults(newPoint, point);
+                return defaults(newPoint, point);
             })
         };
 
-        return _.defaults(newSeries, series);
+        return defaults(newSeries, series);
     });
 
-    minY = _.min(lowestY);
-    const stackedMaxY = _.max(stackedY);
+    minY = min(lowestY);
+    const stackedMaxY = max(stackedY);
     maxY = Math.max(stackedMaxY, maxY);
 
     if (normalize) {
 
-        const ratios = _.map(stackedY, y => stackedMaxY / y);
-        series = _.map(series, series => {
+        const ratios = map(stackedY, y => stackedMaxY / y);
+        series = map(series, series => {
             const newSeries = {
-                data: _.map(series.data, (point, pointIndex) => {
+                data: map(series.data, (point, pointIndex) => {
                     const newPoint = {
                         y0: point.y0 * ratios[pointIndex],
                         y: point.y * ratios[pointIndex]
                     };
-                    return _.defaults(newPoint, point);
+                    return defaults(newPoint, point);
                 })
             };
-            return _.defaults(newSeries, series);
+            return defaults(newSeries, series);
         });
 
     }

--- a/src/helpers/transforms/transpose.js
+++ b/src/helpers/transforms/transpose.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import { defaults, forEach } from 'lodash';
 
 export default function transpose(props) {
 
@@ -6,11 +6,11 @@ export default function transpose(props) {
 
     let maxX = 0;
     const newSeries = [];
-    _.forEach(series, (series, seriesIndex) => {
-        _.forEach(series.data, (point, pointIndex) => {
+    forEach(series, (series, seriesIndex) => {
+        forEach(series.data, (point, pointIndex) => {
             newSeries[pointIndex] = newSeries[pointIndex] || {data: []};
             maxX = Math.max(maxX, seriesIndex);
-            newSeries[pointIndex].data[seriesIndex] = _.defaults({
+            newSeries[pointIndex].data[seriesIndex] = defaults({
                 realX: point.x,
                 x: seriesIndex
             }, point);

--- a/src/helpers/transforms/unstack.js
+++ b/src/helpers/transforms/unstack.js
@@ -1,18 +1,18 @@
-import _ from 'lodash';
+import { defaults, map, omit } from 'lodash';
 
 export default function unstack(props) {
 
     const {series, seriesNormalized, maxX, maxY, minX, minY} = props;
 
-    const newSeries = _.map(series, series => {
+    const newSeries = map(series, series => {
         const newSeries = {
-            data: _.map(series.data, point => {
-                const newPoint = _.omit(point, ['y0', 'y']);
+            data: map(series.data, point => {
+                const newPoint = omit(point, ['y0', 'y']);
                 newPoint.y = point.y - point.y0;
                 return newPoint;
             })
         };
-        return _.defaults(newSeries, series);
+        return defaults(newSeries, series);
     }, []);
 
     return {

--- a/src/helpers/value.js
+++ b/src/helpers/value.js
@@ -1,13 +1,21 @@
-import _ from 'lodash';
+import {
+    defaults,
+    forEach,
+    isArray,
+    isFunction,
+    isNull,
+    isPlainObject,
+    isUndefined,
+} from 'lodash';
 
 export default function value(attribute, args) {
-    if (_.isArray(attribute)) {
+    if (isArray(attribute)) {
         let result;
-        _.forEach(attribute, attr => {
-            attr = _.isFunction(attr) ? attr(args) : attr;
-            if (_.isPlainObject(attr) && _.isUndefined(attr._owner) && _.isUndefined(attr.props)) {
-                result = _.defaults(result || {}, attr);
-            } else if (!_.isUndefined(attr) && !_.isNull(attr)) {
+        forEach(attribute, attr => {
+            attr = isFunction(attr) ? attr(args) : attr;
+            if (isPlainObject(attr) && isUndefined(attr._owner) && isUndefined(attr.props)) {
+                result = defaults(result || {}, attr);
+            } else if (!isUndefined(attr) && !isNull(attr)) {
                 result = attr;
                 return false;
             } else {
@@ -16,6 +24,6 @@ export default function value(attribute, args) {
         });
         return result;
     } else {
-        return _.isFunction(attribute) ? attribute(args) : attribute;
+        return isFunction(attribute) ? attribute(args) : attribute;
     }
 }


### PR DESCRIPTION
Replaced lodash imports by importing only stuff used from the library, as I noticed that lodash is the biggest thing in my application. By adding these there is more than 500kb saved.

You can check the comparison (this is in development mode, non-uglified, but it gives significant improvement in production mode as well, and much less code for browser to parse):

<img width="671" alt="lodash" src="https://user-images.githubusercontent.com/776788/27586425-9289f744-5b40-11e7-9ab6-7e408de891ec.png">

~~EDIT: Do you know if the the same is doable with `d3`?~~
EDIT2: Just tried, there is no improvement with the same approach applied to d3.